### PR TITLE
deprecate device shots

### DIFF
--- a/src/iqpopt/iqp_optimizer.py
+++ b/src/iqpopt/iqp_optimizer.py
@@ -178,8 +178,9 @@ class IqpSimulator:
             return jnp.array(samples)
 
         else:
-            dev = qml.device(self.device, wires=self.n_qubits, shots=shots)
+            dev = qml.device(self.device, wires=self.n_qubits)
 
+            @qml.set_shots(shots)
             @qml.qnode(dev)
             def sample_circuit(params):
                 self.iqp_circuit(params, init_coefs)


### PR DESCRIPTION
PennyLane has already deprecated the shots setting on device level. Instead, we use `qml.set_shots` on the `QNode` definition to pass this information