### PR TITLE
Update code to work with new Pennylane shots

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,34 +40,8 @@ For example, in the above the function
 `local_gates` returns `gates = [[[0]],[[1]],[[0,1]]]` which specifies three trainable parameters with gate generators
 $X_0$, $X_1$ and $X_0X_1$. 
 
-One can also specify some gates to have fixed, non-trainable parameters. For example,
-
-
-[//]: # (The gate list )
-
-[//]: # ()
-[//]: # (```python)
-
-[//]: # (gates = [[[0],[1]], [[0,1]]])
-
-[//]: # (```)
-
-[//]: # ()
-[//]: # (assigns the *same* trainable parameter to the generators $X_0$, $X_1$ and a second trainable parameter)
-
-[//]: # (to the generator $X_0X_1$. )
-
-[//]: # ()
-[//]: # (Non-trainable gates can be specified by the optional arguments `init_gates` and `init_coefs`. For example,)
-
-```python
-circuit = iqp.IqpSimulator(n_qubits, gates = [[[0]],[[1]]], init_gates = [[[0,1]]])
-```
-defines a circuit with two trainable gates with generators $X_0$ and $X_1$ and one non-trainable gate with generator $X_0X_1$ that will be applied at the start of the circuit. When evaluating the expectation value of the circuit, both parameters for the trainable gates (`params`) and parameters for the non-trainable ones (`init_coefs`) have to be specified.
-
 > **Note**: For very large problems it can be useful to initialize the circuit with the option `sparse=True`. 
 > This uses scipy sparse matrix multiplication in place of JAX and can be significantly more memory efficient.
-
 
 ## Expectation values
 IQPopt has been designed for fast evaluation of expectation values of Pauli Z tensors.

--- a/src/iqpopt/iqp_optimizer.py
+++ b/src/iqpopt/iqp_optimizer.py
@@ -178,8 +178,9 @@ class IqpSimulator:
             return jnp.array(samples)
 
         else:
-            dev = qml.device(self.device, wires=self.n_qubits, shots=shots)
+            dev = qml.device(self.device, wires=self.n_qubits)
 
+            @qml.set_shots(shots)
             @qml.qnode(dev)
             def sample_circuit(params):
                 self.iqp_circuit(params, init_coefs)
@@ -407,6 +408,9 @@ class IqpSimulator:
         Returns:
             list: List of Vectors. The expected value of each op and its standard deviation.
         """
+
+        if self.init_gates is not None and init_coefs is None:
+            raise ValueError("init_coefs cannot be None if init_gates are specified")
 
         if ops.ndim == 1:
             ops = ops.reshape(1, -1)

--- a/src/iqpopt/iqp_optimizer.py
+++ b/src/iqpopt/iqp_optimizer.py
@@ -406,8 +406,66 @@ class IqpSimulator:
             list: List of Vectors. The expected value of each op and its standard deviation.
         """
 
+        # if max_batch_ops is None:
+        #     max_batch_ops = len(ops)
+        #
+        # if max_batch_samples is None:
+        #     max_batch_samples = n_samples
+        #
+        # if self.bitflip:
+        #     n_samples = max_batch_samples
+        #
+        # if len(ops.shape) == 1:
+        #     ops = ops.reshape(1, -1)
+        #
+        # if self.bitflip:
+        #     expvals = jnp.empty((0, 1))
+        # else:
+        #     expvals = jnp.empty((0, n_samples))
+        #
+        # init_coefs = jnp.array(init_coefs) if init_coefs is not None else None
+        # expvals_across_samples = []
+        #
+        # # Iterate over batches of samples
+        # num_sample_batches = int(np.ceil(n_samples / max_batch_samples))
+        # for i in range(num_sample_batches):
+        #     batch_n_samples = min(max_batch_samples, n_samples - i * max_batch_samples)
+        #     key, subkey = jax.random.split(key, 2)
+        #     expvals_across_ops = []
+        #     # Inner loop: Iterate over batches of operators
+        #     num_op_batches = int(np.ceil(ops.shape[0] / max_batch_ops))
+        #     for batch_ops in jnp.array_split(ops, num_op_batches):
+        #         batch_expval = self.op_expval_batch(
+        #             params, batch_ops, batch_n_samples, subkey, init_coefs,
+        #             indep_estimates, return_samples=True
+        #         )
+        #         expvals_across_ops.append(batch_expval)
+        #
+        #     # Concatenate results from all operator batches for the current sample batch
+        #     expvals_for_sample_batch = jnp.concatenate(expvals_across_ops, axis=0)
+        #     expvals_across_samples.append(expvals_for_sample_batch)
+        #
+        # # Concatenate results from all sample batches to form the final array
+        # expvals = jnp.concatenate(expvals_across_samples, axis=-1)
+        # if self.bitflip:
+        #     if return_samples:
+        #         return expvals
+        #     else:
+        #         return jnp.mean(expvals, axis=-1), jnp.zeros(len(ops))
+        # else:
+        #     if return_samples:
+        #         return expvals
+        #     else:
+        #         return jnp.mean(expvals, axis=-1), jnp.std(expvals, axis=-1, ddof=1)/jnp.sqrt(n_samples)
+
+        # --- Initial Setup ---
+        if ops.ndim == 1:
+            ops = ops.reshape(1, -1)
+
+        original_ops_shape = ops.shape
+
         if max_batch_ops is None:
-            max_batch_ops = len(ops)
+            max_batch_ops = ops.shape[0]
 
         if max_batch_samples is None:
             max_batch_samples = n_samples
@@ -415,35 +473,69 @@ class IqpSimulator:
         if self.bitflip:
             n_samples = max_batch_samples
 
-        if len(ops.shape) == 1:
-            ops = ops.reshape(1, -1)
-
-        if self.bitflip:
-            expvals = jnp.empty((0, 1))
-        else:
-            expvals = jnp.empty((0, n_samples))
-
         init_coefs = jnp.array(init_coefs) if init_coefs is not None else None
-        
-        for batch_ops in jnp.array_split(ops, np.ceil(ops.shape[0] / max_batch_ops)):
-            tmp_expvals = jnp.empty((len(batch_ops), 0))
-            for i in range(np.ceil(n_samples / max_batch_samples).astype(jnp.int64)):
-                batch_n_samples = min(max_batch_samples, n_samples - i * max_batch_samples)
-                key, subkey = jax.random.split(key, 2)
+
+        # --- Padding for lax loops ---
+        # Pad ops so its length is a multiple of max_batch_ops
+        op_pad_len = (max_batch_ops - ops.shape[0] % max_batch_ops) % max_batch_ops
+        padded_ops = jnp.pad(ops, ((0, op_pad_len), (0, 0)))
+        num_op_batches = padded_ops.shape[0] // max_batch_ops
+
+        # Calculate number of sample batches. We always process max_batch_samples per batch.
+        num_sample_batches = int(np.ceil(n_samples / max_batch_samples))
+
+        # --- JIT-friendly Loop Definition ---
+        def sample_loop_body(i, state):
+            key, accumulated_expvals = state
+            key, subkey = jax.random.split(key)
+
+            # Define inner loop body here to capture the correct subkey for this sample batch
+            def op_loop_body(j, expvals_for_sample_batch):
+                op_start_idx = j * max_batch_ops
+                batch_ops = jax.lax.dynamic_slice(
+                    padded_ops, (op_start_idx, 0), (max_batch_ops, padded_ops.shape[1])
+                )
+
                 batch_expval = self.op_expval_batch(
-                    params, batch_ops, batch_n_samples, subkey, init_coefs,
+                    params, batch_ops, max_batch_samples, subkey, init_coefs,
                     indep_estimates, return_samples=True
                 )
-                tmp_expvals = jnp.concatenate((tmp_expvals, batch_expval), axis=-1)
-            expvals = jnp.concatenate((expvals, tmp_expvals), axis=0)
 
+                return jax.lax.dynamic_update_slice(
+                    expvals_for_sample_batch, batch_expval, (op_start_idx, 0)
+                )
+
+            # Run the inner loop over operator batches
+            init_inner_results = jnp.zeros((padded_ops.shape[0], max_batch_samples))
+            expvals_one_sample_batch = jax.lax.fori_loop(0, num_op_batches, op_loop_body, init_inner_results)
+
+            # Update the total results array with the results from this sample batch
+            sample_start_idx = i * max_batch_samples
+            updated_total_expvals = jax.lax.dynamic_update_slice(
+                accumulated_expvals, expvals_one_sample_batch, (0, sample_start_idx)
+            )
+
+            return key, updated_total_expvals
+
+        # --- Execute Main Loop ---
+        total_padded_samples = num_sample_batches * max_batch_samples
+        init_outer_state = (key, jnp.zeros((padded_ops.shape[0], total_padded_samples)))
+
+        _, padded_expvals = jax.lax.fori_loop(0, num_sample_batches, sample_loop_body, init_outer_state)
+
+        # --- Post-processing ---
+        # Unpad the final results array to the original requested dimensions
+        expvals = padded_expvals[:ops.shape[0], :n_samples]
+
+        # Final processing and return logic
         if self.bitflip:
             if return_samples:
                 return expvals
             else:
-                return jnp.mean(expvals, axis=-1), jnp.zeros(len(ops))
+                return jnp.mean(expvals, axis=-1), jnp.zeros(ops.shape[0])
         else:
             if return_samples:
                 return expvals
             else:
-                return jnp.mean(expvals, axis=-1), jnp.std(expvals, axis=-1, ddof=1)/jnp.sqrt(n_samples)
+                std_err = jnp.std(expvals, axis=-1, ddof=1) / jnp.sqrt(n_samples)
+                return jnp.mean(expvals, axis=-1), std_err


### PR DESCRIPTION
The `circuit.sample` method has been updated since the device shots argument will be depreciated in PennyLane (see [here](https://github.com/PennyLaneAI/pennylane/pull/7979)). Shots are now taken using a Qnode decorator match the new syntax.  

README has been updated since the previous change moving `init_coeffs` to `op_expval` was causing an error when running the readme code in sequence. We will likely depreciate `init_gates` and `init_coeffs` in a future release, since the same functionality can be achieved using `gates`.