### PR TITLE
Fix `init_coefs` list support for matmul in `op_expval_batch`

### DIFF
--- a/src/iqpopt/iqp_optimizer.py
+++ b/src/iqpopt/iqp_optimizer.py
@@ -279,7 +279,7 @@ class IqpSimulator:
         samples = jax.random.randint(key, (n_samples, self.n_qubits), 0, 2)
         
         effective_params = self.trans_par @ params if self.par_transform else params
-        effective_params = effective_params + self.trans_coef @ init_coefs if self.init_gates is not None else effective_params
+        effective_params = effective_params + self.trans_coef @ jnp.asarray(init_coefs, dtype=self.trans_coef.dtype) if self.init_gates is not None else effective_params
 
         if self.bitflip:
 


### PR DESCRIPTION
This PR fixes a `TypeError` I encountered in `op_expval_batch` when `init_gates` are enabled and `init_coefs` is provided as a Python `list[float]`. JAX rejects `ArrayImpl @ list`, causing an exception when computing the `effective_params`.

Bug:
In `op_expval_batch`:
```python
effective_params = effective_params + self.trans_coef @ init_coefs if self.init_gates is not None else effective_params
```
When `init_coefs` is a list, this raises:
```python
TypeError: unsupported operand type(s) for @: 'ArrayImpl' and 'list'
```

Fix:
Convert `init_coefs` to a JAX array in the same line it is matmul'ed with `self.trans_coef`